### PR TITLE
Fix memory leaks

### DIFF
--- a/MGSpriteView/MGSampleRect.m
+++ b/MGSpriteView/MGSampleRect.m
@@ -29,32 +29,31 @@
 {
     self = [super init];
     if (self) {
-
-        CGFloat factor = [[UIScreen mainScreen] scale] == 1.0 ? 0.5 : 1.0;
+		
         self.rotated = rotated;
-
+		
         if (self.rotated) {
-            self.contentRect = CGRectMake(frame.origin.x * factor / size.width,
-                                          frame.origin.y * factor / size.height,
-                                          frame.size.height * factor / size.width,
-                                          frame.size.width * factor / size.height);
+            self.contentRect = CGRectMake(frame.origin.x / size.width,
+                                          frame.origin.y / size.height,
+                                          frame.size.height / size.width,
+                                          frame.size.width / size.height);
             self.bounds = CGRectMake(0,
                                      0,
-                                     frame.size.height * factor,
-                                     frame.size.width * factor);
+                                     frame.size.height,
+                                     frame.size.width);
         } else {
-            self.contentRect = CGRectMake(frame.origin.x * factor / size.width,
-                                          frame.origin.y * factor / size.height,
-                                          frame.size.width * factor / size.width,
-                                          frame.size.height * factor / size.height);
+            self.contentRect = CGRectMake(frame.origin.x / size.width,
+                                          frame.origin.y / size.height,
+                                          frame.size.width / size.width,
+                                          frame.size.height / size.height);
             self.bounds = CGRectMake(0,
                                      0,
-                                     frame.size.width * factor,
-                                     frame.size.height * factor);
+                                     frame.size.width,
+                                     frame.size.height);
         }
         
         // WHY + and - ? May be bec
-        self.offset = CGPointMake(offset.x * factor, -offset.y * factor);
+        self.offset = CGPointMake(offset.x, -offset.y);
         
         self.sourceColorRect = sourceColorRect;
         self.sourceSize = sourceSize;

--- a/MGSpriteView/MGSpriteAnimationSequence.m
+++ b/MGSpriteView/MGSpriteAnimationSequence.m
@@ -11,7 +11,7 @@
 @property (nonatomic, strong) NSArray *animations;
 @property (nonatomic, assign) NSUInteger animationIndex;
 @property (nonatomic, strong) MGSpriteView *currentAnimation;
-@property (nonatomic, strong) MGSpriteAnimationCallback callback;
+@property (nonatomic, copy) MGSpriteAnimationCallback callback;
 @end
 
 
@@ -41,6 +41,11 @@
     return self;
 }
 
+- (void)dealloc
+{
+	NSLog(@"### dealloc %@",NSStringFromClass([self class]));
+}
+
 - (void)runWithCallback:(MGSpriteAnimationCallback)callback
 {
     self.animationIndex = 0;
@@ -59,21 +64,23 @@
                                scaleFactor:newAnimation.scaleFactor
                                        fps:newAnimation.fps];
     
+	__weak typeof(self) bself = self;
     [self.currentAnimation runAnimationWithMode:MGSpriteViewAnimationModeDisplayLink
                                completeCallback:^{
-                                   self.animationIndex++;
-                                   if (self.animationIndex < [self.animations count]) {
-                                       [self runCurrentAnimation];
+                                   bself.animationIndex++;
+                                   if (bself.animationIndex < [bself.animations count]) {
+                                       [bself runCurrentAnimation];
                                    } else {
-                                       if (self.callback) self.callback();
+                                       if (bself.callback) bself.callback();
                                    }
                                }];
 }
 
 - (void)runLooped
 {
+	__weak typeof(self) bself = self;
     [self runWithCallback:^{
-        [self runLooped];
+        [bself runLooped];
     }];
 }
 

--- a/MGSpriteView/MGSpriteSheetParser.m
+++ b/MGSpriteView/MGSpriteSheetParser.m
@@ -13,7 +13,19 @@
 
 - (NSArray *)sampleRectsFromFileAtPath:(NSString *)path
 {
-    NSString *bundlePath = [[NSBundle mainBundle] pathForResource:path ofType:nil];
+	NSString* bundlePath = [[NSBundle mainBundle] pathForResource:path ofType:nil];
+	
+	// manually check if retina version exists
+	if ([[UIScreen mainScreen] respondsToSelector:@selector(displayLinkWithTarget:selector:)] &&
+		([UIScreen mainScreen].scale == 2.0)) {
+		NSString* retinaBundlePath = [NSString stringWithFormat:@"%@@2x.%@",[path stringByDeletingPathExtension],[path pathExtension]];
+		retinaBundlePath = [[NSBundle mainBundle] pathForResource:retinaBundlePath ofType:nil];
+		if (retinaBundlePath)
+		{
+			bundlePath = retinaBundlePath;
+		}
+	}
+	
     NSDictionary *data = [NSDictionary dictionaryWithContentsOfFile:bundlePath];
     if (data) {
         
@@ -22,7 +34,7 @@
         NSDictionary *frames = [data objectForKey:@"frames"];
         NSArray *keys = [frames allKeys];
         NSArray *sortedKeys = [keys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
-
+		
         CGSize size = CGSizeMake(CGImageGetWidth(self.imageRef), CGImageGetHeight(self.imageRef));
         for (NSString *key in sortedKeys) {
             NSString *frame = [[frames objectForKey:key] objectForKey:@"frame"];
@@ -67,7 +79,7 @@
     NSArray *coords = [pointString componentsSeparatedByString:@","];
     if ([coords count] == 2) {
         return CGPointMake([coords[0] floatValue],
-                          [coords[1] floatValue]);
+						   [coords[1] floatValue]);
     } else {
         return CGPointZero;
     }
@@ -80,7 +92,7 @@
     NSArray *dimensions = [sizeString componentsSeparatedByString:@","];
     if ([dimensions count] == 2) {
         return CGSizeMake([dimensions[0] floatValue],
-                           [dimensions[1] floatValue]);
+						  [dimensions[1] floatValue]);
     } else {
         return CGSizeZero;
     }

--- a/MGSpriteView/MGSpriteView.h
+++ b/MGSpriteView/MGSpriteView.h
@@ -42,6 +42,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
 - (void)runAnimationLooped;
 
 - (void)pause;
+- (void)stop;
 
 - (CFTimeInterval)duration;
 

--- a/MGSpriteView/MGSpriteView.m
+++ b/MGSpriteView/MGSpriteView.m
@@ -16,7 +16,7 @@
 @property (nonatomic, assign) NSUInteger fps;
 @property (nonatomic, assign) CGFloat scaleFactor;
 @property (nonatomic, assign) CGImageRef image;
-@property (nonatomic, strong) MGSpriteAnimationCallback completeCallback;
+@property (nonatomic, copy) MGSpriteAnimationCallback completeCallback;
 @property (nonatomic, assign) MGSpriteViewAnimationMode animationMode;
 - (NSUInteger)numberOfFrames;
 - (void)setPositionWithSample:(MGSampleRect *)sample;
@@ -79,6 +79,17 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
                    sampleRects:sampleRects
                    scaleFactor:scaleFactor
                            fps:fps];
+}
+
+- (void)dealloc
+{
+	NSLog(@"### dealloc %@",NSStringFromClass([self class]));
+	[self.drawingTimer invalidate];
+	[self.animatedLayer removeFromSuperlayer];
+	[self.view removeFromSuperview];
+	self.drawingTimer = nil;
+	self.animatedLayer = nil;
+	self.view = nil;
 }
 
 #pragma mark - Getters
@@ -234,7 +245,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
     [self.drawingTimer setPaused:YES];
 }
 
-#pragma mark - 
+#pragma mark -
 
 - (void)displayAnimatedLayerWithSample:(MGSampleRect *)sample
 {

--- a/MGSpriteView/MGSpriteView.m
+++ b/MGSpriteView/MGSpriteView.m
@@ -16,6 +16,7 @@
 @property (nonatomic, assign) NSUInteger fps;
 @property (nonatomic, assign) CGFloat scaleFactor;
 @property (nonatomic, assign) CGImageRef image;
+@property (nonatomic, assign) BOOL looping;
 @property (nonatomic, copy) MGSpriteAnimationCallback completeCallback;
 @property (nonatomic, assign) MGSpriteViewAnimationMode animationMode;
 - (NSUInteger)numberOfFrames;
@@ -47,6 +48,7 @@
         self.sampleRects = sampleRects;
         self.scaleFactor = scaleFactor;
         self.image = image;
+		self.looping = NO;
         self.animatedLayer = [MCSpriteLayer layerWithImage:self.image];
         self.animatedLayer.delegate = self;
         
@@ -159,6 +161,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
 
 - (void)runAnimation
 {
+	self.looping = NO;
     [self runAnimationWithCompleteCallback:nil];
 }
 
@@ -169,9 +172,8 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
 
 - (void)runAnimationLooped
 {
-    [self runAnimationWithCompleteCallback:^{
-        [self runAnimationLooped];
-    }];
+	self.looping = YES;
+    [self runAnimationWithCompleteCallback:nil];
 }
 
 #pragma mark - Animation - CADisplayLink
@@ -192,17 +194,20 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
     
     NSUInteger newIndex = self.drawingElapsedTime / (1.0 / self.fps);
     if (newIndex != self.drawingIndex) {
-        if (newIndex < [self.sampleRects count]) {
-            MGSampleRect *sample = nil;
-            if (newIndex == 0) {
-                sample = self.sampleRects[newIndex];
-            } else {
-                sample = self.sampleRects[newIndex - 1];
+		if (self.looping && newIndex >= [self.sampleRects count])
+		{
+			newIndex = newIndex % [self.sampleRects count];
+			CGFloat duration =(1.0/self.fps)*[self.sampleRects count];
+			self.drawingElapsedTime -= duration;
             }
+		
+        if (newIndex < [self.sampleRects count]) {
+            MGSampleRect *sample = self.sampleRects[newIndex];
             [self displayAnimatedLayerWithSample:sample];
             
             self.drawingIndex = newIndex;
-        } else {
+        }
+		else {
             [self.drawingTimer invalidate];
             if (self.completeCallback) self.completeCallback();
         }
@@ -216,13 +221,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
     if (layer == self.animatedLayer) {
         MCSpriteLayer *spriteLayer = (MCSpriteLayer*)layer;
         unsigned int index = [spriteLayer currentSampleIndex];
-        MGSampleRect *sample = nil;
-        
-        if (index == 0) {
-            sample = self.sampleRects[index];
-        } else {
-            sample = self.sampleRects[index - 1];
-        }
+        MGSampleRect *sample = self.sampleRects[index];
         
         [self displayAnimatedLayerWithSample:sample];
         
@@ -250,6 +249,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
 	[self.drawingTimer invalidate];
 	self.drawingTimer = nil;
 	self.completeCallback = nil;
+	self.looping = NO;
 }
 
 #pragma mark -

--- a/MGSpriteView/MGSpriteView.m
+++ b/MGSpriteView/MGSpriteView.m
@@ -152,7 +152,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
         if (self.drawingTimer) [self.drawingTimer invalidate];
         
         self.drawingTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(redraw:)];
-        [self.drawingTimer addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+        [self.drawingTimer addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
     }
 }
 

--- a/MGSpriteView/MGSpriteView.m
+++ b/MGSpriteView/MGSpriteView.m
@@ -244,6 +244,12 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
     // TODO - It doesn't handle the CAAnimation case!!!
     [self.drawingTimer setPaused:YES];
 }
+- (void)stop
+{
+	[self.drawingTimer invalidate];
+	self.drawingTimer = nil;
+	self.completeCallback = nil;
+}
 
 #pragma mark -
 

--- a/MGSpriteView/MGSpriteView.m
+++ b/MGSpriteView/MGSpriteView.m
@@ -199,7 +199,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
 			newIndex = newIndex % [self.sampleRects count];
 			CGFloat duration =(1.0/self.fps)*[self.sampleRects count];
 			self.drawingElapsedTime -= duration;
-            }
+		}
 		
         if (newIndex < [self.sampleRects count]) {
             MGSampleRect *sample = self.sampleRects[newIndex];
@@ -294,13 +294,12 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
     CGFloat maxWidth = 0;
     CGFloat maxHeight = 0;
     for (MGSampleRect *sampleRect in sampleRects) {
-        CGFloat width = sampleRect.rotated ? sampleRect.bounds.size.height : sampleRect.bounds.size.width;
-        CGFloat height = sampleRect.rotated ? sampleRect.bounds.size.width : sampleRect.bounds.size.height;
-        if (width > maxWidth) {
-            maxWidth = width;
+		// use source size to work out placement intended (rect would be in the same space)
+        if (sampleRect.sourceSize.width > maxWidth) {
+            maxWidth = sampleRect.sourceSize.width;
         }
-        if (height > maxHeight) {
-            maxHeight = height;
+        if (sampleRect.sourceSize.height > maxHeight) {
+            maxHeight = sampleRect.sourceSize.height;
         }
     }
     

--- a/MGSpriteView/MGSpriteView.m
+++ b/MGSpriteView/MGSpriteView.m
@@ -90,6 +90,7 @@ spriteSheetFileName:(NSString *)spriteSheetFilename
 	self.drawingTimer = nil;
 	self.animatedLayer = nil;
 	self.view = nil;
+	self.completeCallback = nil;
 }
 
 #pragma mark - Getters


### PR DESCRIPTION
I didn't realise this but often there were retain locks because of the callbacks, resulting in constant memory leaks.

So the changes to the callbacks below are because of this, so that the class doesn't take add to the retain count in a callback. This makes it correctly dealloc when it's owner is destroyed.

The other changes is to invalidate and remove objects which we have ownership of but might also exist outside of it's scope. Now that it's correctly dealloc'd it would have caused runtime crashes because of this.
